### PR TITLE
Design: 중복 스타일 제거

### DIFF
--- a/src/components/coffee/MyCoffeeSum.tsx
+++ b/src/components/coffee/MyCoffeeSum.tsx
@@ -1,14 +1,14 @@
 import SumBoard from '@/components/coffee/SumBoard';
 import { COFFEE_TEXTS } from '@/constants/coffee';
-import { styled } from 'styled-system/jsx';
-import { Semibold } from '@/styles/styles';
+import { cx } from 'styled-system/css';
+import { SumTitle, PaddingT22 } from '@/styles/styles';
 
 const { sum } = COFFEE_TEXTS;
 
 const MyCoffeeSum = () => {
   return (
     <>
-      <Title className={Semibold}>{sum}</Title>
+      <h2 className={cx(SumTitle, PaddingT22)}>{sum}</h2>
       <SumBoard
         period="이번 주"
         coffeeAmount={20}
@@ -28,11 +28,5 @@ const MyCoffeeSum = () => {
     </>
   );
 };
-
-const Title = styled.h2`
-  padding-top: 22px;
-  font-size: var(--font-sizes-lg);
-  line-height: 26px;
-`;
 
 export default MyCoffeeSum;

--- a/src/components/coffee/SumBoard.tsx
+++ b/src/components/coffee/SumBoard.tsx
@@ -2,6 +2,7 @@ import SumByType from '@/components/coffee/SumByType';
 import { COFFEE_TEXTS } from '@/constants/coffee';
 import { styled } from 'styled-system/jsx';
 import { Column, Evenly, Flex } from '@/styles/layout';
+import { SumBoardTitle, SumType } from '@/styles/styles';
 import { cx } from 'styled-system/css';
 
 const { intake, cups, unit, coffee, caffeine, year, month } = COFFEE_TEXTS;
@@ -19,15 +20,15 @@ const SumBoard = ({
   const YearPredi = typeof period === 'number' && period > 13;
   return (
     <Container>
-      <Title>
+      <div className={SumBoardTitle}>
         {period}
         {MonthPredi && month}
         {YearPredi && year} {intake}
-      </Title>
+      </div>
 
       <InfoArea className={cx(Flex, Evenly)}>
         <div className={Column}>
-          <SumType>{coffee}</SumType>
+          <div className={SumType}>{coffee}</div>
           <SumByType
             amount={coffeeAmount}
             unit={cups}
@@ -35,7 +36,7 @@ const SumBoard = ({
         </div>
         <Divider />
         <div className={Column}>
-          <SumType>{caffeine}</SumType>
+          <div className={SumType}>{caffeine}</div>
           <SumByType
             amount={caffeineAmount}
             unit={unit}
@@ -55,17 +56,6 @@ const Container = styled.div`
 
 const InfoArea = styled.div`
   position: relative;
-`;
-
-const Title = styled.div`
-  font-weight: 500;
-  font-size: var(--font-sizes-sm);
-`;
-
-const SumType = styled.div`
-  font-size: var(--font-sizes-xs);
-  line-height: 20px;
-  color: #767676;
 `;
 
 const Divider = styled.div`

--- a/src/components/coffee/SumByType.tsx
+++ b/src/components/coffee/SumByType.tsx
@@ -1,28 +1,14 @@
 import { Flex } from '@/styles/layout';
-import { styled } from 'styled-system/jsx';
+import { SumTypeAmount, SumTypeUnit } from '@/styles/styles';
 
 const SumByType = ({ amount, unit }: { amount: number; unit: string }) => {
   return (
     <div className={Flex}>
-      <Amount>{amount}</Amount>
+      <div className={SumTypeAmount}>{amount}</div>
       &nbsp;
-      <Unit>{unit}</Unit>
+      <div className={SumTypeUnit}>{unit}</div>
     </div>
   );
 };
-
-const Amount = styled.div`
-  font-size: var(--font-sizes-xl);
-  font-weight: 700;
-  color: var(--colors-main);
-  line-height: 28px;
-`;
-
-const Unit = styled.div`
-  font-size: var(--font-sizes-sm);
-  font-weight: 500;
-  line-height: 28px;
-  transform: translateY(7%);
-`;
 
 export default SumByType;

--- a/src/components/common/CaffeineInfo.tsx
+++ b/src/components/common/CaffeineInfo.tsx
@@ -1,12 +1,12 @@
 import { CAFFEINE_INFO_TEXTS } from '@/constants/home';
-import { Align, Between, Flex } from '@/styles/layout';
+import { Align, Between } from '@/styles/layout';
 import { HomeRegistContainer, HomeInfoCaffeine } from '@/styles/styles';
 import { cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 
 const CaffeineInfo = () => {
   return (
-    <Container className={cx(Flex, Between, HomeRegistContainer, Align)}>
+    <Container className={cx(Between, HomeRegistContainer, Align)}>
       <span>{CAFFEINE_INFO_TEXTS.title}</span>
       <span className={HomeInfoCaffeine}>0mg</span>
     </Container>

--- a/src/components/common/CaffeineInfo.tsx
+++ b/src/components/common/CaffeineInfo.tsx
@@ -1,14 +1,14 @@
+import { CAFFEINE_INFO_TEXTS } from '@/constants/home';
 import { Align, Between, Flex } from '@/styles/layout';
-import { Medium, Semibold } from '@/styles/styles';
+import { HomeRegistContainer, HomeInfoCaffeine } from '@/styles/styles';
 import { cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
-import { CAFFEINE_INFO_TEXTS } from '@/constants/home';
 
 const CaffeineInfo = () => {
   return (
-    <Container className={cx(Flex, Between, Medium, Align)}>
+    <Container className={cx(Flex, Between, HomeRegistContainer, Align)}>
       <span>{CAFFEINE_INFO_TEXTS.title}</span>
-      <Caffeine className={Semibold}>0mg</Caffeine>
+      <span className={HomeInfoCaffeine}>0mg</span>
     </Container>
   );
 };
@@ -17,15 +17,6 @@ const Container = styled.div`
   margin: 16px 0 12px;
   border-top: 1px solid #ccc;
   padding: 14px;
-  color: #313131;
-  font-size: var(--font-sizes-base);
-  line-height: 24px;
-`;
-
-const Caffeine = styled.span`
-  color: var(--colors-main);
-  font-size: var(--font-sizes-xl);
-  line-height: 28px;
 `;
 
 export default CaffeineInfo;

--- a/src/components/common/CoffeeOptionSelection.tsx
+++ b/src/components/common/CoffeeOptionSelection.tsx
@@ -122,7 +122,7 @@ const CoffeeOptionSelection = () => {
       <ShotOptionInputContainer
         className={cx(Align, Between, MarginB8, SmStyle)}>
         <span>{coffeeOption.shot.input}</span>
-        <div className={cx(Flex, Align)}>
+        <div className={Align}>
           <Icon
             {...iconPropsGenerator(
               !inputValue ? 'input-minus' : 'input-minus:active'

--- a/src/components/common/CoffeeOptionSelection.tsx
+++ b/src/components/common/CoffeeOptionSelection.tsx
@@ -1,17 +1,16 @@
 import { TouchEvent, useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
 import { useParams } from 'react-router-dom';
+import { caffeineFilterState, registPostState } from '@/atoms/atoms';
+import RegisterLabel from '@/components/post/RegisterLabel';
 import Button from '@/components/common/Button';
 import Icon from '@/components/common/Icon';
 import { CAFFEINE_FILTER_TEXTS } from '@/constants/home';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
-
 import { css, cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
-import { BtnColorWhite, Medium } from '@/styles/styles';
-import { Align, Between, Column, Flex, Grid } from '@/styles/layout';
-import RegisterLabel from '@/components/post/RegisterLabel';
-import { caffeineFilterState, registPostState } from '@/atoms/atoms';
-import { useRecoilState } from 'recoil';
+import { BtnColorWhite, SmStyle, MarginB6, MarginB8 } from '@/styles/styles';
+import { Align, Between, Column, Flex } from '@/styles/layout';
 
 const { coffeeOption } = CAFFEINE_FILTER_TEXTS;
 
@@ -90,15 +89,15 @@ const CoffeeOptionSelection = () => {
   }, []);
 
   return (
-    <Container className={cx(Column, Medium)}>
-      <span className={BottomMargin6}>
+    <div className={cx(Column, SmStyle)}>
+      <span className={MarginB6}>
         {!register ? (
           coffeeOption.size
         ) : (
           <RegisterLabel label={coffeeOption.size} />
         )}
       </span>
-      <SizeBtnContainer className={cx(Flex, Grid, BottomMargin8)}>
+      <SizeBtnContainer className={cx(Flex, MarginB8)}>
         {size.map(item => (
           <Button
             key={item}
@@ -107,13 +106,13 @@ const CoffeeOptionSelection = () => {
             onTouchEnd={selectSize}
             className={cx(
               sizeValue === item ? SelectSizeBtn : BtnColorWhite,
-              Medium,
-              SizeBtn
+              SizeBtn,
+              SmStyle
             )}
           />
         ))}
       </SizeBtnContainer>
-      <span className={BottomMargin6}>
+      <span className={MarginB6}>
         {!register ? (
           coffeeOption.shot.title
         ) : (
@@ -121,7 +120,7 @@ const CoffeeOptionSelection = () => {
         )}
       </span>
       <ShotOptionInputContainer
-        className={cx(Flex, Align, Between, BottomMargin8)}>
+        className={cx(Align, Between, MarginB8, SmStyle)}>
         <span>{coffeeOption.shot.input}</span>
         <div className={cx(Flex, Align)}>
           <Icon
@@ -131,7 +130,6 @@ const CoffeeOptionSelection = () => {
             onTouchEnd={selectMinusBtn}
           />
           <ShotOptionInput
-            className={Medium}
             type="number"
             value={inputValue}
             readOnly
@@ -143,7 +141,7 @@ const CoffeeOptionSelection = () => {
           />
         </div>
       </ShotOptionInputContainer>
-    </Container>
+    </div>
   );
 };
 
@@ -153,46 +151,25 @@ const ShotOptionInputContainer = styled.div`
   border-radius: 10px;
   border: 1px solid #ccc;
   background: #fff;
-  color: #313131;
-  font-size: var(--font-sizes-sm);
 `;
-
 const ShotOptionInput = styled.input`
   text-align: center;
   width: 40px;
+  background-color: transparent;
 `;
-
-const Container = styled.div`
-  color: #313131;
-  font-size: var(--font-sizes-sm);
-  line-height: 22px;
-`;
-
-const BottomMargin6 = css`
-  margin-bottom: 6px;
-`;
-
-const BottomMargin8 = css`
-  margin-bottom: 8px;
-`;
-
 const SizeBtnContainer = styled.div`
   gap: 4px;
 `;
-
 const SelectSizeBtn = css`
   border: 1px solid var(--colors-main);
   background-color: var(--colors-main);
-  color: #fff;
+  color: #fff !important;
 `;
-
 const SizeBtn = css`
   min-width: 104px;
   width: 100%;
   height: 40px;
   border-radius: 50px;
-  font-size: var(--font-sizes-sm);
-  line-height: 22px;
 `;
 
 export default CoffeeOptionSelection;

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import FooterIcon from '@/components/common/FooterIcon';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
-import FooterIcon from '@/components/common/FooterIcon';
 import { Flex, Between } from '@/styles/layout';
 
 const icons = ['home', 'feed', 'coffee', 'my'];

--- a/src/components/common/FooterIcon.tsx
+++ b/src/components/common/FooterIcon.tsx
@@ -1,11 +1,12 @@
 import { useRecoilState } from 'recoil';
-import { css, cx } from 'styled-system/css';
 import { activeState } from '@/atoms/atoms';
 import Icon from '@/components/common/Icon';
 import { useNavigateTo } from '@/hooks/useNavigateTo';
+import useGetCacheData from '@/hooks/useGetCacheData';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { Column, Center } from '@/styles/layout';
-import useGetCacheData from '@/hooks/useGetCacheData';
+import { FooterTextMedium, FooterTextSelected } from '@/styles/styles';
+import { cx } from 'styled-system/css';
 
 const userId = useGetCacheData('user', '/userId');
 
@@ -33,7 +34,8 @@ const FooterIcon = ({ icon }: { icon: string }) => {
           <Icon
             {...iconPropsGenerator(active === icon ? `${icon}-active` : icon)}
           />
-          <span className={active === icon ? Selected : Text}>
+          <span
+            className={active === icon ? FooterTextSelected : FooterTextMedium}>
             {icon.toUpperCase()}
           </span>
         </div>
@@ -41,16 +43,5 @@ const FooterIcon = ({ icon }: { icon: string }) => {
     </>
   );
 };
-
-const Text = css`
-  font-weight: 500;
-  font-size: var(--font-sizes-xxs);
-`;
-
-const Selected = css`
-  font-size: var(--font-sizes-xxs);
-  font-weight: 600;
-  color: var(--colors-main);
-`;
 
 export default FooterIcon;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -21,7 +21,7 @@ const Header = () => {
   const close = icon === 'close';
 
   return (
-    <Container className={cx(Flex, Between, Align)}>
+    <Container className={cx(Between, Align)}>
       <Left onTouchEnd={useNavigateTo('/')}>
         {logo && (
           <svg

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,11 +1,12 @@
 import { useRecoilValue } from 'recoil';
-import HeaderCloseIcon from '@/components/common/HeaderCloseIcon';
-import HeaderIcons from '@/components/common/HeaderIcons';
 import {
   headerTextState,
   headerLogoState,
   headerIconsState
 } from '@/atoms/atoms';
+import HeaderCloseIcon from '@/components/common/HeaderCloseIcon';
+import HeaderIcons from '@/components/common/HeaderIcons';
+import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 import { Between, Flex, Align } from '@/styles/layout';
@@ -21,7 +22,7 @@ const Header = () => {
 
   return (
     <Container className={cx(Flex, Between, Align)}>
-      <Left>
+      <Left onTouchEnd={useNavigateTo('/')}>
         {logo && (
           <svg
             width={'80'}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,5 +1,4 @@
 import { useRecoilValue } from 'recoil';
-
 import HeaderCloseIcon from '@/components/common/HeaderCloseIcon';
 import HeaderIcons from '@/components/common/HeaderIcons';
 import {
@@ -8,8 +7,9 @@ import {
   headerIconsState
 } from '@/atoms/atoms';
 import { styled } from 'styled-system/jsx';
-import { cx, css } from 'styled-system/css';
+import { cx } from 'styled-system/css';
 import { Between, Flex, Align } from '@/styles/layout';
+import { HeaderText, PaddingL63, PaddingL24 } from '@/styles/styles';
 
 const Header = () => {
   const logo = useRecoilValue(headerLogoState);
@@ -30,9 +30,13 @@ const Header = () => {
           </svg>
         )}
       </Left>
-      <Center className={icons ? IconsSpace : close ? CloseSpace : ''}>
+      <h2
+        className={cx(
+          icons ? PaddingL63 : close ? PaddingL24 : '',
+          HeaderText
+        )}>
         {text}
-      </Center>
+      </h2>
       <Right className={Flex}>
         {icons && <HeaderIcons />}
         {close && <HeaderCloseIcon />}
@@ -57,20 +61,8 @@ const Nav = styled.nav`
 
 const Left = styled(Nav)``;
 
-const Center = styled.h2`
-  font-size: var(--font-sizes-lg);
-  font-weight: 500;
-`;
-
 const Right = styled.span`
   gap: 15px;
-`;
-
-const IconsSpace = css`
-  padding-left: 63px;
-`;
-const CloseSpace = css`
-  padding-left: 24px;
 `;
 
 export default Header;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,13 +1,17 @@
 import Icon from '@/components/common/Icon';
 import { INPUT_TEXTS } from '@/constants/common';
-import { InputProps } from '@/types/types';
+import { useInput } from '@/hooks/useInput';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
-
+import { InputProps } from '@/types/types';
 import { styled } from 'styled-system/jsx';
 import { Align, Between } from '@/styles/layout';
 import { css, cx } from 'styled-system/css';
-import { InputFontSm, InputFontBase } from '@/styles/styles';
-import { useInput } from '@/hooks/useInput';
+import {
+  InputFontSm,
+  InputFontBase,
+  InputByteCheck,
+  BgF5
+} from '@/styles/styles';
 
 export const Input = ({ type, handleEvent }: InputProps) => {
   const { nickname, comment, title, search } = INPUT_TEXTS.type;
@@ -54,9 +58,7 @@ export const Input = ({ type, handleEvent }: InputProps) => {
     <InputContainer
       tabIndex={0}
       className={
-        type === title.typeName
-          ? cx(Align, Between, TitleInput)
-          : cx(Align, Between)
+        type === title.typeName ? cx(Align, Between, BgF5) : cx(Align, Between)
       }>
       <input
         className={InputFontBase}
@@ -68,10 +70,10 @@ export const Input = ({ type, handleEvent }: InputProps) => {
       />
       <InputBox className={Align}>
         {inputLength && (
-          <InpoutLength className={Align}>
+          <div className={cx(Align, InputByteCheck)}>
             {inputValue?.length}
             <LengthLimit>/{inputLength}</LengthLimit>
-          </InpoutLength>
+          </div>
         )}
         {submitBtn}
       </InputBox>
@@ -93,19 +95,6 @@ const InputContainer = styled.div`
 const InputBox = styled.div`
   height: 50px;
   gap: 8px;
-`;
-
-const TitleInput = css`
-  background-color: #f5f5f5;
-`;
-
-const InpoutLength = styled.div`
-  color: #313131;
-  font-family: Pretendard;
-  font-size: var(--font-sizes-xs);
-  font-style: normal;
-  font-weight: 400;
-  line-height: 20px;
 `;
 
 const LengthLimit = styled.div`

--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -5,6 +5,7 @@ import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { css, cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 import { Align, Between } from '@/styles/layout';
+import { HomeRegistContainer, InputByteCheck } from '@/styles/styles';
 
 const { nickname, gender } = LABEL_TEXTS;
 
@@ -24,20 +25,21 @@ export const Label = ({ inputValue, isAlert, label, message }: LabelProps) => {
     );
 
   const alretMessage = (
-    <LabelMessage
-      className={
+    <span
+      className={cx(
         message && message === nickname.message.disapproval
           ? ErrorMessage
-          : DefaltMessage
-      }>
+          : DefaltMessage,
+        InputByteCheck
+      )}>
       {message}
-    </LabelMessage>
+    </span>
   );
 
   return (
     <LabelContainer className={cx(Align, Between)}>
       <div className={Align}>
-        <LabelText>{label}</LabelText>
+        <LabelText className={HomeRegistContainer}>{label}</LabelText>
         {label === nickname.label && nicknameCheckIcon}
         {label === gender.label && genderCheckIcon}
       </div>
@@ -53,17 +55,7 @@ export const LabelContainer = styled.div`
 `;
 
 export const LabelText = styled.div`
-  color: #313131;
   margin-right: 4px;
-  font-size: var(--font-sizes-base);
-  font-weight: 500;
-  line-height: 24px;
-`;
-
-export const LabelMessage = styled.span`
-  font-size: var(--font-sizes-xs);
-  font-weight: 400;
-  line-height: 20px;
 `;
 
 export const ErrorMessage = css`

--- a/src/components/common/MiniProfile.tsx
+++ b/src/components/common/MiniProfile.tsx
@@ -3,7 +3,7 @@ import { TEXT } from '@/constants/texts';
 import { SimplifyUser } from '@/types/types';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { Column, Flex, FlexCenter, Justify } from '@/styles/layout';
-import { LineH18, Semibold } from '@/styles/styles';
+import { ProfileInfo, ProfileTitle } from '@/styles/styles';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 
@@ -14,12 +14,11 @@ const MiniProfile: React.FC<SimplifyUser> = ({ NickName, caffeine }) => {
         <Icon {...iconPropsGenerator('mini-user', '44')} />
       </div>
       <div className={cx(Column, Justify)}>
-        <UserTitle className={cx(LineH18, Semibold)}>{NickName}</UserTitle>
-        <UserCafein
-          className={cx(
-            Flex,
-            LineH18
-          )}>{`${TEXT.addedcaffeine} ${caffeine} ${TEXT.mgLabel}`}</UserCafein>
+        <span className={ProfileTitle}>{NickName}</span>
+        <span
+          className={
+            ProfileInfo
+          }>{`${TEXT.addedcaffeine} ${caffeine} ${TEXT.mgLabel}`}</span>
       </div>
     </Container>
   );
@@ -27,12 +26,6 @@ const MiniProfile: React.FC<SimplifyUser> = ({ NickName, caffeine }) => {
 
 const Container = styled.div`
   gap: 12px;
-`;
-const UserTitle = styled.span`
-  font-size: var(--font-sizes-sm);
-`;
-const UserCafein = styled.span`
-  font-size: var(--font-sizes-xs);
 `;
 
 export default MiniProfile;

--- a/src/components/follow/UserListItem.tsx
+++ b/src/components/follow/UserListItem.tsx
@@ -2,8 +2,7 @@ import MiniProfile from '@/components/common/MiniProfile';
 import { TEXT } from '@/constants/texts';
 import { SimplifyUser } from '@/types/types';
 import { Align, Between } from '@/styles/layout';
-import { LineH18, Cursor } from '@/styles/styles';
-import { Medium } from '@/styles/styles';
+import { PaddingT20, DelBtn, Cursor } from '@/styles/styles';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 
@@ -11,32 +10,26 @@ const UserListItem: React.FC<{ users: SimplifyUser[] }> = ({ users }) => {
   return (
     <>
       {users.map(({ userId, NickName, caffeine }: SimplifyUser) => (
-        <Container
+        <div
           key={userId}
-          className={cx(Align, Between)}>
+          className={cx(Align, Between, PaddingT20)}>
           <MiniProfile
             userId={userId}
             NickName={NickName}
             caffeine={caffeine}
           />
-          <DeleteBtn className={cx(Cursor, LineH18, Medium)}>
-            {TEXT.deleteBtn}
-          </DeleteBtn>
-        </Container>
+          <DeleteBtn className={cx(Cursor, DelBtn)}>{TEXT.deleteBtn}</DeleteBtn>
+        </div>
       ))}
     </>
   );
 };
 
-const Container = styled.div`
-  padding-top: 20px;
-`;
 const DeleteBtn = styled.button`
   width: 50px;
   height: 30px;
   border-radius: 6px;
   background-color: var(--colors-tertiary);
-  font-size: var(--font-sizes-xs);
 `;
 
 export default UserListItem;

--- a/src/components/home/CaffeineFilter.tsx
+++ b/src/components/home/CaffeineFilter.tsx
@@ -20,8 +20,8 @@ const CaffeineFilter = () => {
   );
 };
 
-export default CaffeineFilter;
-
 const Container = styled.div`
   margin: 32px 0 32px;
 `;
+
+export default CaffeineFilter;

--- a/src/components/home/CaffeineInfo.tsx
+++ b/src/components/home/CaffeineInfo.tsx
@@ -1,15 +1,15 @@
 import { useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { CAFFEINE_INFO_TEXTS } from '@/constants/home';
 import {
   caffeineFilterState,
   selectedMenuInfoState,
   selectedMenuState
 } from '@/atoms/atoms';
+import { CAFFEINE_INFO_TEXTS } from '@/constants/home';
 import { cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 import { HomeRegistContainer, HomeInfoCaffeine } from '@/styles/styles';
-import { Align, Between, Flex } from '@/styles/layout';
+import { Align, Between } from '@/styles/layout';
 
 const CaffeineInfo = () => {
   const selectedMenu = useRecoilValue(selectedMenuState);
@@ -24,7 +24,7 @@ const CaffeineInfo = () => {
   }, [selectedMenu]);
 
   return (
-    <Container className={cx(Flex, Between, HomeRegistContainer, Align)}>
+    <Container className={cx(Between, HomeRegistContainer, Align)}>
       <span>{CAFFEINE_INFO_TEXTS.title}</span>
       <span className={HomeInfoCaffeine}>{caffeine.caffeine}mg</span>
     </Container>

--- a/src/components/home/CaffeineInfo.tsx
+++ b/src/components/home/CaffeineInfo.tsx
@@ -6,10 +6,9 @@ import {
   selectedMenuInfoState,
   selectedMenuState
 } from '@/atoms/atoms';
-
 import { cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
-import { Medium, Semibold } from '@/styles/styles';
+import { HomeRegistContainer, HomeInfoCaffeine } from '@/styles/styles';
 import { Align, Between, Flex } from '@/styles/layout';
 
 const CaffeineInfo = () => {
@@ -25,9 +24,9 @@ const CaffeineInfo = () => {
   }, [selectedMenu]);
 
   return (
-    <Container className={cx(Flex, Between, Medium, Align)}>
+    <Container className={cx(Flex, Between, HomeRegistContainer, Align)}>
       <span>{CAFFEINE_INFO_TEXTS.title}</span>
-      <Caffeine className={Semibold}>{caffeine.caffeine}mg</Caffeine>
+      <span className={HomeInfoCaffeine}>{caffeine.caffeine}mg</span>
     </Container>
   );
 };
@@ -36,15 +35,6 @@ const Container = styled.div`
   margin: 16px 0 12px;
   border-top: 1px solid #ccc;
   padding: 14px;
-  color: #313131;
-  font-size: var(--font-sizes-base);
-  line-height: 24px;
-`;
-
-const Caffeine = styled.span`
-  color: var(--colors-main);
-  font-size: var(--font-sizes-xl);
-  line-height: 28px;
 `;
 
 export default CaffeineInfo;

--- a/src/components/home/CoffeeIntake.tsx
+++ b/src/components/home/CoffeeIntake.tsx
@@ -1,3 +1,4 @@
+import { DocumentData } from 'firebase/firestore';
 import { CAFFEINE_PER_WATER_TEXTS } from '@/constants/home';
 import { FlexCenter } from '@/styles/layout';
 import {
@@ -7,7 +8,6 @@ import {
   HomeContentNum,
   InputByteCheck
 } from '@/styles/styles';
-import { DocumentData } from 'firebase/firestore';
 import { css, cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 
@@ -21,8 +21,8 @@ const CoffeeIntake = ({ data }: { data: DocumentData[] }) => {
     <div>
       <div className={CaffeineDetail}>{coffeeIntake.title}</div>
       <div className={HomeContent}>
-        <span className={HomeContentBigNum}>{data.Allcaffeine}</span>mg
-        <span className={HomeContentNum}> /{data.coffee}잔</span>
+        <span className={HomeContentBigNum}>{allCaffeine}</span>mg
+        <span className={HomeContentNum}> /{data.length}잔</span>
       </div>
       <div className={InputByteCheck}>{coffeeIntake.subTitle}</div>
       <div className={FlexCenter}>

--- a/src/components/home/CoffeeIntake.tsx
+++ b/src/components/home/CoffeeIntake.tsx
@@ -1,6 +1,12 @@
 import { CAFFEINE_PER_WATER_TEXTS } from '@/constants/home';
-import { Align, Flex } from '@/styles/layout';
-import { Bold, Regular, Semibold } from '@/styles/styles';
+import { FlexCenter } from '@/styles/layout';
+import {
+  CaffeineDetail,
+  HomeContent,
+  HomeContentBigNum,
+  HomeContentNum,
+  InputByteCheck
+} from '@/styles/styles';
 import { DocumentData } from 'firebase/firestore';
 import { css, cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
@@ -13,23 +19,21 @@ const CoffeeIntake = ({ data }: { data: DocumentData[] }) => {
 
   return (
     <div>
-      <Title className={Regular}>{coffeeIntake.title}</Title>
-      <ContentContainer className={Semibold}>
-        <CaffeineNum className={Bold}>{allCaffeine}</CaffeineNum>mg
-        <CoffeeNum> /{data.length}잔</CoffeeNum>
-      </ContentContainer>
-      <div className={CaffeineProgress}>{coffeeIntake.subTitle}</div>
-      <div className={cx(Flex, Align)}>
+      <div className={CaffeineDetail}>{coffeeIntake.title}</div>
+      <div className={HomeContent}>
+        <span className={HomeContentBigNum}>{data.Allcaffeine}</span>mg
+        <span className={HomeContentNum}> /{data.coffee}잔</span>
+      </div>
+      <div className={InputByteCheck}>{coffeeIntake.subTitle}</div>
+      <div className={FlexCenter}>
         <ProgressBar>
-          <Progress></Progress>
+          <Progress />
         </ProgressBar>
-        <div className={cx(CaffeineProgress, recommended)}>400mg</div>
+        <div className={cx(InputByteCheck, recommended)}>400mg</div>
       </div>
     </div>
   );
 };
-
-export default CoffeeIntake;
 
 const ProgressBar = styled.div`
   position: relative;
@@ -46,26 +50,8 @@ const Progress = styled.div`
   border-radius: 5px;
   background-color: var(--colors-main);
 `;
-const Title = styled.div`
-  font-size: var(--font-sizes-sm);
-`;
-
-const CaffeineNum = styled.span`
-  font-size: var(--font-sizes-xxl);
-  line-height: 40px;
-`;
-
-const CoffeeNum = styled.span`
-  color: #313131;
-`;
-
-const ContentContainer = styled.div`
-  color: var(--main, #ff701e);
-`;
-
-const CaffeineProgress = css`
-  font-size: var(--font-sizes-sm);
-`;
 const recommended = css`
   color: #767676;
 `;
+
+export default CoffeeIntake;

--- a/src/components/home/CoffeeMenuSelection.tsx
+++ b/src/components/home/CoffeeMenuSelection.tsx
@@ -1,25 +1,22 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
-
-import RegisterLabel from '@/components/post/RegisterLabel';
-import { CAFFEINE_FILTER_TEXTS } from '@/constants/home';
-import useGetCacheData from '@/hooks/useGetCacheData';
-import { CoffeeData, UserCachedData } from '@/types/types';
-import { setBrnadList } from '@/utils/setBrandList';
-import coffeeData from '@/datas/coffees';
-
-import { css, cx } from 'styled-system/css';
-import { styled } from 'styled-system/jsx';
-import { Medium } from '@/styles/styles';
-import { Column, Flex, Grid } from '@/styles/layout';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import {
   registPostState,
   selectedBrandState,
   selectedMenuInfoState,
   selectedMenuState
 } from '@/atoms/atoms';
-import convertBrandName from '@/utils/convertBrandName';
+import RegisterLabel from '@/components/post/RegisterLabel';
+import { CAFFEINE_FILTER_TEXTS } from '@/constants/home';
+import useGetCacheData from '@/hooks/useGetCacheData';
+import { CoffeeData, UserCachedData } from '@/types/types';
+import { setBrnadList } from '@/utils/setBrandList';
+import coffeeData from '@/datas/coffees';
+import { css, cx } from 'styled-system/css';
+import { styled } from 'styled-system/jsx';
+import { SmStyle } from '@/styles/styles';
+import { Column, Flex } from '@/styles/layout';
 
 const { coffeeMenu } = CAFFEINE_FILTER_TEXTS;
 
@@ -91,8 +88,8 @@ const CoffeeMenuSelection = () => {
 
   return (
     <div className={MarginTop}>
-      {!register && <span className={cx(Medium)}>{coffeeMenu.title}</span>}
-      <CoffeeSelectContainer className={cx(register ? Column : Flex, Grid)}>
+      {!register && <span className={SmStyle}>{coffeeMenu.title}</span>}
+      <CoffeeSelectContainer className={cx(register ? Column : Flex)}>
         {register && (
           <RegisterLabel
             label={coffeeMenu.brand}
@@ -101,7 +98,7 @@ const CoffeeMenuSelection = () => {
         )}
         <SelectBox className={selectedBrand ? seletedBorder : defaultBorder}>
           <select
-            className={cx(SelectInput, Medium)}
+            className={cx(SelectInput, SmStyle)}
             name={coffeeMenu.brand}
             id={coffeeMenu.brand}
             value={selectedBrand}
@@ -134,7 +131,7 @@ const CoffeeMenuSelection = () => {
         )}
         <SelectBox className={selectedMenu ? seletedBorder : defaultBorder}>
           <select
-            className={cx(SelectInput, Medium)}
+            className={cx(SelectInput, SmStyle)}
             name={coffeeMenu.menu}
             id={coffeeMenu.menu}
             value={selectedMenu}

--- a/src/components/home/CoffeeMenuSelection.tsx
+++ b/src/components/home/CoffeeMenuSelection.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import {
   registPostState,
   selectedBrandState,
@@ -9,10 +9,11 @@ import {
 } from '@/atoms/atoms';
 import RegisterLabel from '@/components/post/RegisterLabel';
 import { CAFFEINE_FILTER_TEXTS } from '@/constants/home';
+import coffeeData from '@/datas/coffees';
 import useGetCacheData from '@/hooks/useGetCacheData';
 import { CoffeeData, UserCachedData } from '@/types/types';
+import convertBrandName from '@/utils/convertBrandName';
 import { setBrnadList } from '@/utils/setBrandList';
-import coffeeData from '@/datas/coffees';
 import { css, cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 import { SmStyle } from '@/styles/styles';

--- a/src/components/home/CoffeeSelection.tsx
+++ b/src/components/home/CoffeeSelection.tsx
@@ -1,15 +1,14 @@
-import Icon from '@/components/common/Icon';
-import CoffeeOptionSelection from '@/components/common/CoffeeOptionSelection';
-import CoffeeMenuSelection from '@/components/home/CoffeeMenuSelection';
-import { CAFFEINE_FILTER_TEXTS } from '@/constants/home';
-import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
-
 import { useResetRecoilState } from 'recoil';
 import { registPostState } from '@/atoms/atoms';
+import CoffeeOptionSelection from '@/components/common/CoffeeOptionSelection';
+import CoffeeMenuSelection from '@/components/home/CoffeeMenuSelection';
+import Icon from '@/components/common/Icon';
+import { CAFFEINE_FILTER_TEXTS } from '@/constants/home';
+import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 import { Align, Between, Flex } from '@/styles/layout';
-import { Medium, Semibold } from '@/styles/styles';
+import { SmStyle, SumBoardTitle, SumTitle } from '@/styles/styles';
 
 const { title } = CAFFEINE_FILTER_TEXTS;
 
@@ -21,33 +20,23 @@ const CoffeeSelection = () => {
   };
 
   return (
-    <Container>
-      <Title className={cx(Semibold, Flex, Between)}>
+    <div className={SmStyle}>
+      <span className={cx(SumTitle, Flex, Between)}>
         <span>{title.title}</span>
         <ResetBtn
-          className={cx(Flex, Align, Medium)}
+          className={cx(Align, SumBoardTitle)}
           onTouchEnd={touchResetBtn}>
           <Icon {...iconPropsGenerator('reset', '14')} />
           {title.resetBtn}
         </ResetBtn>
-      </Title>
+      </span>
       <CoffeeMenuSelection />
       <CoffeeOptionSelection />
-    </Container>
+    </div>
   );
 };
 
-const Container = styled.div`
-  color: #313131;
-  font-size: var(--font-sizes-sm);
-  line-height: 22px;
-`;
-const Title = styled.span`
-  font-size: var(--font-sizes-base);
-  line-height: 26px;
-`;
 const ResetBtn = styled.button`
-  font-size: var(--font-sizes-sm);
   gap: 5px;
 `;
 export default CoffeeSelection;

--- a/src/components/home/TodayCaffeineInfo.tsx
+++ b/src/components/home/TodayCaffeineInfo.tsx
@@ -1,9 +1,9 @@
 import { useLayoutEffect, useState, Suspense } from 'react';
+import { getTodayCoffeeInfo } from '@/api/post';
 import TodayCaffeineText from '@/components/home/TodayCaffeineText';
 import WaterPerCoffee from '@/components/home/WaterPerCoffee';
 import useGetCacheData from '@/hooks/useGetCacheData';
 import { CachedData } from '@/types/types';
-import { getTodayCoffeeInfo } from '@/api/post';
 import { styled } from 'styled-system/jsx';
 
 const TodayCaffeineInfo = () => {

--- a/src/components/home/TodayCaffeineInfo.tsx
+++ b/src/components/home/TodayCaffeineInfo.tsx
@@ -2,7 +2,7 @@ import { useLayoutEffect, useState, Suspense } from 'react';
 import TodayCaffeineText from '@/components/home/TodayCaffeineText';
 import WaterPerCoffee from '@/components/home/WaterPerCoffee';
 import useGetCacheData from '@/hooks/useGetCacheData';
-import { CachedData, UserCachedData } from '@/types/types';
+import { CachedData } from '@/types/types';
 import { getTodayCoffeeInfo } from '@/api/post';
 import { styled } from 'styled-system/jsx';
 

--- a/src/components/home/TodayCaffeineText.tsx
+++ b/src/components/home/TodayCaffeineText.tsx
@@ -3,8 +3,11 @@ import { useLayoutEffect, useState } from 'react';
 import { DocumentData } from 'firebase/firestore';
 
 import { authState } from '@/atoms/atoms';
+import { useEffect, useState } from 'react';
 import Icon from '@/components/common/Icon';
 import { TODAY_CAFFEINE_INFO_TEXTS } from '@/constants/home';
+import useGetCacheData from '@/hooks/useGetCacheData';
+import { UserCachedData } from '@/types/types';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import useGetCacheData from '@/hooks/useGetCacheData';
 import { getUserInfo } from '@/api/user';
@@ -13,8 +16,9 @@ import { UserCachedData } from '@/types/types';
 
 import { cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
-import { Align, Between, Column, Flex } from '@/styles/layout';
-import { Regular } from '@/styles/styles';
+import { cx } from 'styled-system/css';
+import { Align, Between, Column } from '@/styles/layout';
+import { HomeHeaderContent, InputFontSm } from '@/styles/styles';
 
 const { anonymous, signedIn } = TODAY_CAFFEINE_INFO_TEXTS;
 
@@ -72,8 +76,8 @@ const TodayCaffeineText = () => {
   );
 
   return (
-    <TodayCaffeineInfoContainer>
-      <div className={cx(Flex, Align, Between)}>
+    <div className={HomeHeaderContent}>
+      <div className={cx(Align, Between)}>
         {user?.signIn ? signedInText : anonymousText}
         <img
           src="/png/coffee_mainimg.png"
@@ -82,26 +86,19 @@ const TodayCaffeineText = () => {
       </div>
       <MessageContainer className={cx(Align)}>
         <Icon {...iconPropsGenerator('message', '15')} />
-        <MessageText className={Regular}>
+        <MessageText className={InputFontSm}>
           {dataList && dataList.length >= 1
             ? signedInMessage
             : anonymous.messageText}
         </MessageText>
       </MessageContainer>
-    </TodayCaffeineInfoContainer>
+    </div>
   );
 };
-
-const TodayCaffeineInfoContainer = styled.div`
-  font-size: var(--font-size-xl);
-  font-weight: 500;
-  line-height: 28px;
-`;
 
 const CaffeineInfo = styled.span`
   color: var(--colors-main);
 `;
-
 const MessageContainer = styled.div`
   padding: 0 16px;
   margin-top: 10px;
@@ -109,9 +106,7 @@ const MessageContainer = styled.div`
   background-color: var(--colors-main);
   color: #fff;
   border-radius: 16px;
-  font-size: var(--font-sizes-sm);
 `;
-
 const MessageText = styled.div`
   margin-left: 12px;
 `;

--- a/src/components/home/TodayCaffeineText.tsx
+++ b/src/components/home/TodayCaffeineText.tsx
@@ -1,20 +1,14 @@
-import { useRecoilValue } from 'recoil';
 import { useLayoutEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 import { DocumentData } from 'firebase/firestore';
-
+import { getUserInfo } from '@/api/user';
+import { getTodayCoffeeInfo } from '@/api/post';
 import { authState } from '@/atoms/atoms';
-import { useEffect, useState } from 'react';
 import Icon from '@/components/common/Icon';
 import { TODAY_CAFFEINE_INFO_TEXTS } from '@/constants/home';
 import useGetCacheData from '@/hooks/useGetCacheData';
 import { UserCachedData } from '@/types/types';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
-import useGetCacheData from '@/hooks/useGetCacheData';
-import { getUserInfo } from '@/api/user';
-import { getTodayCoffeeInfo } from '@/api/post';
-import { UserCachedData } from '@/types/types';
-
-import { cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 import { Align, Between, Column } from '@/styles/layout';

--- a/src/components/home/TodayMenuItem.tsx
+++ b/src/components/home/TodayMenuItem.tsx
@@ -1,4 +1,5 @@
 import Icon from '@/components/common/Icon';
+import { testMenu } from '@/types/types';
 import { Column, Flex } from '@/styles/layout';
 import { Semibold } from '@/styles/styles';
 import { testMenu } from '@/types/types';
@@ -20,14 +21,12 @@ const TodayMenuItem = (data: { data: DocumentData }) => {
         />
       </IconCotainer>
       <div className={Column}>
-        <span className={Semibold}>{data.data.caffeine}mg</span>
-        <span className={SmFont}>{convertBrandName(data.data.brand)}</span>
+        <span className={RecentSearch}>{data.data.caffeine}mg</span>
+        <span className={SumType}>{convertBrandName(data.data.brand)}</span>
       </div>
     </Container>
   );
 };
-
-export default TodayMenuItem;
 
 const Container = styled.div`
   min-width: 134px;
@@ -37,7 +36,6 @@ const Container = styled.div`
   padding: 6px;
   border: 1px solid #ccc;
   background: #fff;
-  line-height: 20px;
 `;
 const IconCotainer = styled.div`
   width: 40px;
@@ -45,6 +43,9 @@ const IconCotainer = styled.div`
   border-radius: 50%;
   margin-right: 10px;
 `;
+
 const SmFont = css`
   font-size: var(--font-sizes-sm);
 `;
+
+export default TodayMenuItem;

--- a/src/components/home/TodayMenuItem.tsx
+++ b/src/components/home/TodayMenuItem.tsx
@@ -1,12 +1,7 @@
-import Icon from '@/components/common/Icon';
-import { testMenu } from '@/types/types';
-import { Column, Flex } from '@/styles/layout';
-import { Semibold } from '@/styles/styles';
-import { testMenu } from '@/types/types';
-import convertBrandName from '@/utils/convertBrandName';
-import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { DocumentData } from 'firebase/firestore';
-import { css } from 'styled-system/css';
+import convertBrandName from '@/utils/convertBrandName';
+import { Column, Flex } from '@/styles/layout';
+import { RecentSearch, SumType } from '@/styles/styles';
 import { styled } from 'styled-system/jsx';
 
 const TodayMenuItem = (data: { data: DocumentData }) => {
@@ -42,10 +37,6 @@ const IconCotainer = styled.div`
   height: 40px;
   border-radius: 50%;
   margin-right: 10px;
-`;
-
-const SmFont = css`
-  font-size: var(--font-sizes-sm);
 `;
 
 export default TodayMenuItem;

--- a/src/components/home/WaterIntake.tsx
+++ b/src/components/home/WaterIntake.tsx
@@ -1,13 +1,13 @@
 import Icon from '@/components/common/Icon';
-import { Align, Justify } from '@/styles/layout';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
+import { FlexCenter } from '@/styles/layout';
 import { css, cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 
 const WaterIntake = () => {
   return (
-    <Container className={cx(Align, Justify)}>
-      <div className={cx(progress, Justify, Align)}>
+    <Container className={FlexCenter}>
+      <div className={cx(progress, FlexCenter)}>
         <img
           src="/png/waterCup.png"
           alt="water"
@@ -19,8 +19,6 @@ const WaterIntake = () => {
     </Container>
   );
 };
-
-export default WaterIntake;
 
 const Container = styled.div`
   position: relative;
@@ -42,3 +40,5 @@ const IconContainer = styled.div`
   right: 30px;
   bottom: 25px;
 `;
+
+export default WaterIntake;

--- a/src/components/home/WaterPerCoffee.tsx
+++ b/src/components/home/WaterPerCoffee.tsx
@@ -8,7 +8,6 @@ import WaterIntake from '@/components/home/WaterIntake';
 import { BUTTON_TEXTS } from '@/constants/common';
 import { TODAY_CAFFEINE_INFO_TEXTS } from '@/constants/home';
 import { useNavigateTo } from '@/hooks/useNavigateTo';
-
 import { css, cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 import {
@@ -19,7 +18,7 @@ import {
   Flex,
   MarginAuto
 } from '@/styles/layout';
-import { LoginBtn, Medium, Regular } from '@/styles/styles';
+import { LoginBtn, RegistCoffeeBtn, AlertMessage } from '@/styles/styles';
 
 const { anonymous, signedIn } = TODAY_CAFFEINE_INFO_TEXTS;
 
@@ -41,7 +40,7 @@ const WaterPerCoffee = ({
 
   const anonymousCard = (
     <div className={cx(Column, Center, MarginAuto)}>
-      <span className={cx(AlertMessage, Regular)}>
+      <span className={AlertMessage}>
         {anonymous.card.first} <br /> {anonymous.card.second}
       </span>
       <Button
@@ -54,13 +53,11 @@ const WaterPerCoffee = ({
 
   const notConsumedCoffee = (
     <div className={cx(Column, Center, MarginAuto)}>
-      <span className={cx(AlertMessage, Regular)}>
-        {signedIn.card.notConsumed}
-      </span>
+      <span className={AlertMessage}>{signedIn.card.notConsumed}</span>
       <Button
         text={signedIn.btn}
         onTouchEnd={useNavigateTo('/post/register')}
-        className={cx(RegistCoffeeBtn, Medium)}
+        className={RegistCoffeeBtn}
       />
     </div>
   );
@@ -120,18 +117,6 @@ const Default = css`
   border: 1px solid #ccc;
   background: #ebebeb;
   text-align: center;
-`;
-
-const AlertMessage = css`
-  font-size: var(--font-sizes-sm);
-  color: #a6a6a6;
-  line-height: 22px;
-`;
-
-const RegistCoffeeBtn = css`
-  color: #767676;
-  font-size: var(--font-sizes-xxl);
-  line-height: 32px;
 `;
 
 const MarginTop = css`

--- a/src/components/home/WaterPerCoffee.tsx
+++ b/src/components/home/WaterPerCoffee.tsx
@@ -96,8 +96,6 @@ const WaterPerCoffee = ({
   );
 };
 
-export default WaterPerCoffee;
-
 const Container = styled.div`
   width: inherit;
   height: 220px;
@@ -139,3 +137,5 @@ const RegistCoffeeBtn = css`
 const MarginTop = css`
   margin-top: 16px;
 `;
+
+export default WaterPerCoffee;

--- a/src/components/home/WeeklyPopular.tsx
+++ b/src/components/home/WeeklyPopular.tsx
@@ -1,10 +1,10 @@
 import WeeklyPopularItem from '@/components/home/WeeklyPopularItem';
+import { TODAY_CAFFEINE_INFO_TEXTS } from '@/constants/home';
 import { WeeklyPopularTypes } from '@/types/types';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 import { Grid } from '@/styles/layout';
-import { Medium, Semibold } from '@/styles/styles';
-import { TODAY_CAFFEINE_INFO_TEXTS } from '@/constants/home';
+import { SmStyle, SumTitle, MarginT12 } from '@/styles/styles';
 
 const data: WeeklyPopularTypes[] = [
   {
@@ -32,9 +32,9 @@ const data: WeeklyPopularTypes[] = [
 const WeeklyPopular = () => {
   const { weeklyPopular } = TODAY_CAFFEINE_INFO_TEXTS;
   return (
-    <Container>
-      <div className={Semibold}>{weeklyPopular}</div>
-      <WeeklyPopularList className={cx(Grid, Medium)}>
+    <div>
+      <div className={SumTitle}>{weeklyPopular}</div>
+      <WeeklyPopularList className={cx(Grid, SmStyle, MarginT12)}>
         {data.map(item => (
           <WeeklyPopularItem
             data={item}
@@ -42,18 +42,12 @@ const WeeklyPopular = () => {
           />
         ))}
       </WeeklyPopularList>
-    </Container>
+    </div>
   );
 };
 
-export default WeeklyPopular;
-
 const WeeklyPopularList = styled.div`
-  font-size: var(--font-sizes-base);
-  margin-top: 12px;
   gap: 8px 0;
 `;
-const Container = styled.div`
-  color: #313131;
-  font-size: var(--font-sizes-lg);
-`;
+
+export default WeeklyPopular;

--- a/src/components/home/WeeklyPopularItem.tsx
+++ b/src/components/home/WeeklyPopularItem.tsx
@@ -1,14 +1,13 @@
 import { WeeklyPopularTypes } from '@/types/types';
-import { cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
-import { Align, Flex } from '@/styles/layout';
+import { Align } from '@/styles/layout';
 import convertBrandName from '@/utils/convertBrandName';
 
 const WeeklyPopularItem = ({ data }: { data: WeeklyPopularTypes }) => {
   const icon = `/png/${data.brand}.png`;
 
   return (
-    <Container className={cx(Flex, Align)}>
+    <Container className={Align}>
       <span>{data.ranking}</span>
       <BrandInfo className={cx(Flex, Align)}>
         <Icon>
@@ -23,8 +22,6 @@ const WeeklyPopularItem = ({ data }: { data: WeeklyPopularTypes }) => {
   );
 };
 
-export default WeeklyPopularItem;
-
 const Container = styled.div`
   height: 54px;
   border-radius: 50px;
@@ -32,7 +29,6 @@ const Container = styled.div`
   background: #fff;
 `;
 const BrandInfo = styled.div`
-  font-size: var(--font-sizes-sm);
   margin-left: 20px;
 `;
 const Icon = styled.div`
@@ -42,3 +38,5 @@ const Icon = styled.div`
   background-color: darkkhaki;
   margin-right: 12px;
 `;
+
+export default WeeklyPopularItem;

--- a/src/components/home/WeeklyPopularItem.tsx
+++ b/src/components/home/WeeklyPopularItem.tsx
@@ -1,7 +1,7 @@
 import { WeeklyPopularTypes } from '@/types/types';
+import convertBrandName from '@/utils/convertBrandName';
 import { styled } from 'styled-system/jsx';
 import { Align } from '@/styles/layout';
-import convertBrandName from '@/utils/convertBrandName';
 
 const WeeklyPopularItem = ({ data }: { data: WeeklyPopularTypes }) => {
   const icon = `/png/${data.brand}.png`;
@@ -9,7 +9,7 @@ const WeeklyPopularItem = ({ data }: { data: WeeklyPopularTypes }) => {
   return (
     <Container className={Align}>
       <span>{data.ranking}</span>
-      <BrandInfo className={cx(Flex, Align)}>
+      <BrandInfo className={Align}>
         <Icon>
           <img
             src={icon}

--- a/src/components/mypage/MyProfile.tsx
+++ b/src/components/mypage/MyProfile.tsx
@@ -4,7 +4,12 @@ import { TEXT } from '@/constants/texts';
 import { useComposeHeader } from '@/hooks/useComposeHeader';
 import { useImgSubmit } from '@/hooks/useImgSubmit';
 import { FlexCenter, Justify } from '@/styles/layout';
-import { Cursor, LineH18, TextGray, Border16, Medium } from '@/styles/styles';
+import {
+  Cursor,
+  SumType,
+  Border16,
+  HomeRegistContainer
+} from '@/styles/styles';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 
@@ -26,13 +31,13 @@ const MyProfile = () => {
       <EditProfileImg onImageSelect={handleImageSelect} />
       <CheckNickname />
       <ExitButton
-        className={cx(Cursor, LineH18, TextGray)}
+        className={cx(Cursor, SumType)}
         onTouchEnd={handleExitedUser}>
         {TEXT.exitButtonText}
       </ExitButton>
       <ButtonArea className={Justify}>
         <SaveButton
-          className={cx(FlexCenter, Cursor, Border16, Medium)}
+          className={cx(FlexCenter, Cursor, Border16, HomeRegistContainer)}
           onTouchEnd={handleFormSubmit}>
           {TEXT.saveButton}
         </SaveButton>
@@ -42,7 +47,6 @@ const MyProfile = () => {
 };
 
 const ExitButton = styled.span`
-  font-size: var(--font--sizes-sm);
   padding: 16px 0;
   display: inline-block;
   text-decoration-line: underline;
@@ -56,7 +60,6 @@ const SaveButton = styled.button`
   width: 100%;
   height: 60px;
   background-color: var(--colors-main);
-  font-size: var(--font-sizes-base);
-  color: #fff;
+  color: #fff !important;
 `;
 export default MyProfile;

--- a/src/components/notification/ProfileIcon.tsx
+++ b/src/components/notification/ProfileIcon.tsx
@@ -9,7 +9,7 @@ const Container = styled.div`
   min-width: 40px;
   min-height: 40px;
   background-color: yellow;
-  border-radius: 999px;
+  border-radius: 100%;
 `;
 
 export default ProfileIcon;

--- a/src/components/post/CafeDetail.tsx
+++ b/src/components/post/CafeDetail.tsx
@@ -1,7 +1,7 @@
 import Icon from '@/components/common/Icon';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { cx } from 'styled-system/css';
-import { Column, Flex, Align } from '@/styles/layout';
+import { Column, Align } from '@/styles/layout';
 import { Cafe, CaffeineDetail, PaddingL6, PostsCafe } from '@/styles/styles';
 
 // 하드코딩 텍스트 데이터로 변경예정
@@ -16,15 +16,15 @@ const CafeDetail = ({
 }) => {
   return (
     <div className={cx(Column, className)}>
-      <div className={posts ? cx(PostsCafe, Flex, Align) : Cafe}>
+      <div className={posts ? cx(PostsCafe, Align) : Cafe}>
         {posts && <Icon {...iconPropsGenerator('shop', '16')} />}
         <span className={PaddingL6}>{brand}</span>
       </div>
-      <CaffeineDetail>
+      <div className={CaffeineDetail}>
         ICED 아메리카노 (+2샷)
         <br />
         포함된 카페인 함량은 185mg입니다.
-      </CaffeineDetail>
+      </div>
     </div>
   );
 };

--- a/src/components/post/CaffeineInfo.tsx
+++ b/src/components/post/CaffeineInfo.tsx
@@ -1,12 +1,11 @@
 import CafeDetail from '@/components/post/CafeDetail';
 import { styled } from 'styled-system/jsx';
-import { cx } from 'styled-system/css';
-import { Flex, Align } from '@/styles/layout';
+import { Align } from '@/styles/layout';
 import { PaddingL12 } from '@/styles/styles';
 
 const CaffeineInfo = ({ brand }: { brand: string }) => {
   return (
-    <Container className={cx(Flex, Align)}>
+    <Container className={Align}>
       <CafeIcon />
       <CafeDetail
         brand={brand}

--- a/src/components/post/Comment.tsx
+++ b/src/components/post/Comment.tsx
@@ -2,6 +2,8 @@ import Icon from '@/components/common/Icon';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { styled } from 'styled-system/jsx';
 import { Flex, Column } from '@/styles/layout';
+import { CommnetUser, CaffeineDetail, TextArea } from '@/styles/styles';
+import { cx } from 'styled-system/css';
 
 // 하드코딩 텍스트 데이터로 변경예정
 const Comment = () => {
@@ -9,9 +11,9 @@ const Comment = () => {
     <Container className={Flex}>
       <Icon {...iconPropsGenerator('comment-default', '36')} />
       <CommentDetail className={Column}>
-        <UserName>프리한 프리지아</UserName>
-        <CommentText>커피 ㄲ</CommentText>
-        <OnComment className={Flex}>
+        <div className={CommnetUser}>프리한 프리지아</div>
+        <div className={CaffeineDetail}>커피 ㄲ</div>
+        <OnComment className={cx(Flex, TextArea)}>
           <CommentedAt>23분 전</CommentedAt>
           <Reply>답글 달기</Reply>
         </OnComment>
@@ -27,20 +29,8 @@ const Container = styled.div`
 const CommentDetail = styled.div`
   padding-left: 8px;
 `;
-const UserName = styled.div`
-  font-weight: 600;
-  font-size: var(--font-sizes-sm);
-  line-height: 22px;
-`;
-
-const CommentText = styled.div`
-  font-size: var(--font-sizes-sm);
-  line-height: 22px;
-`;
 
 const OnComment = styled.div`
-  font-size: var(--font-sizes-xs);
-  line-height: 20px;
   color: #a6a6a6;
 `;
 

--- a/src/components/post/PostComments.tsx
+++ b/src/components/post/PostComments.tsx
@@ -1,9 +1,11 @@
-import { styled } from 'styled-system/jsx';
 import Comment from '@/components/post/Comment';
+import { styled } from 'styled-system/jsx';
+import { CommentLength } from '@/styles/styles';
+
 const PostComments = ({ length }: { length: number }) => {
   return (
     <Container>
-      <Length>{length}개의 댓글</Length>
+      <div className={CommentLength}>{length}개의 댓글</div>
       <Comment />
     </Container>
   );
@@ -11,12 +13,6 @@ const PostComments = ({ length }: { length: number }) => {
 
 const Container = styled.div`
   padding-top: 16px;
-`;
-
-const Length = styled.div`
-  font-size: var(--font-sizes-sm);
-  line-height: 22px;
-  color: #767676;
 `;
 
 export default PostComments;

--- a/src/components/post/PostDetail.tsx
+++ b/src/components/post/PostDetail.tsx
@@ -5,14 +5,13 @@ import CaffeineInfo from '@/components/post/CaffeineInfo';
 import PostedAt from '@/components/post/PostedAt';
 import Icon from '@/components/common/Icon';
 import { Input } from '@/components/common/Input';
-
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { INPUT_TEXTS } from '@/constants/common';
+import { SimplifyUser } from '@/types/types';
 import { styled } from 'styled-system/jsx';
-import { Flex, Between, Align } from '@/styles/layout';
+import { Between, Align } from '@/styles/layout';
 import { cx } from 'styled-system/css';
 import { PaddingTB10, PostContent } from '@/styles/styles';
-import { SimplifyUser } from '@/types/types';
 
 // POST 정보를 수신 => 하위 props에 전달
 // 1. PostSocial => 좋아요, 댓글 수
@@ -26,7 +25,7 @@ const PostDetail = ({ userId, NickName, caffeine }: SimplifyUser) => {
 
   return (
     <>
-      <UserProfile className={cx(Flex, Between, Align)}>
+      <UserProfile className={cx(Between, Align)}>
         <MiniProfile
           userId={userId}
           NickName={NickName}

--- a/src/components/post/PostRegister.tsx
+++ b/src/components/post/PostRegister.tsx
@@ -20,7 +20,7 @@ import Icon from '@/components/common/Icon';
 import Button from '@/components/common/Button';
 import { css, cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
-import { Center, Flex } from '@/styles/layout';
+import { FlexCenter } from '@/styles/layout';
 import { DefaultBtn } from '@/styles/styles';
 
 const editorDefaults = getEditorDefaults({
@@ -95,7 +95,7 @@ const PostRegister = () => {
             </PostImgContainer>
           )}
           {!imageUrl && (
-            <RegistPhoto className={cx(Flex, Center)}>
+            <RegistPhoto className={FlexCenter}>
               <Icon {...iconPropsGenerator('regist-photo', '24')} />
               <input
                 ref={fileInputRef}

--- a/src/components/post/PostRegister.tsx
+++ b/src/components/post/PostRegister.tsx
@@ -9,7 +9,6 @@ import { Input } from '@/components/common/Input';
 import CoffeeOptionSelection from '@/components/common/CoffeeOptionSelection';
 import CoffeeMenuSelection from '@/components/home/CoffeeMenuSelection';
 import RegisterLabel from '@/components/post/RegisterLabel';
-
 import { BUTTON_TEXTS, INPUT_TEXTS, LABEL_TEXTS } from '@/constants/common';
 import { registPostState, useInputState } from '@/atoms/atoms';
 import { setPostRegist } from '@/api/post';
@@ -19,7 +18,6 @@ import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import Icon from '@/components/common/Icon';
 import Button from '@/components/common/Button';
-
 import { css, cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 import { Center, Flex } from '@/styles/layout';

--- a/src/components/post/PostSocialCount.tsx
+++ b/src/components/post/PostSocialCount.tsx
@@ -1,13 +1,12 @@
 import Icon from '@/components/common/Icon';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { styled } from 'styled-system/jsx';
-import { cx } from 'styled-system/css';
-import { Align, Flex } from '@/styles/layout';
+import { Align } from '@/styles/layout';
 import { CaffeineDetail } from '@/styles/styles';
 
 const PostSocialCount = ({ count, icon }: { count: number; icon: string }) => {
   return (
-    <Container className={cx(Flex, Align)}>
+    <Container className={Align}>
       <Icon {...iconPropsGenerator(icon)}></Icon>
       <Count className={CaffeineDetail}>{count}</Count>
     </Container>

--- a/src/components/post/PostSocialCount.tsx
+++ b/src/components/post/PostSocialCount.tsx
@@ -3,12 +3,13 @@ import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 import { Align, Flex } from '@/styles/layout';
+import { CaffeineDetail } from '@/styles/styles';
 
 const PostSocialCount = ({ count, icon }: { count: number; icon: string }) => {
   return (
     <Container className={cx(Flex, Align)}>
       <Icon {...iconPropsGenerator(icon)}></Icon>
-      <Count>{count}</Count>
+      <Count className={CaffeineDetail}>{count}</Count>
     </Container>
   );
 };
@@ -19,7 +20,6 @@ const Container = styled.div`
 `;
 
 const Count = styled.span`
-  font-size: var(--font-sizes-sm);
   width: 22px;
 `;
 

--- a/src/components/post/PostedAt.tsx
+++ b/src/components/post/PostedAt.tsx
@@ -1,19 +1,10 @@
-import { css } from 'styled-system/css';
-import { styled } from 'styled-system/jsx';
+import { PaddingTBMix, CafeMedium } from '@/styles/styles';
+import { cx } from 'styled-system/css';
 
 const PostedAt = ({ at, posts = false }: { at: string; posts?: boolean }) => {
-  return <Posted className={posts ? '' : PaddingPost}>{at}분 전</Posted>;
+  return (
+    <div className={cx(posts ? '' : PaddingTBMix, CafeMedium)}>{at}분 전</div>
+  );
 };
-
-const Posted = styled.div`
-  font-size: var(--font-sizes-xs);
-  line-height: 20px;
-  color: #767676;
-`;
-
-const PaddingPost = css`
-  padding-top: 12px;
-  padding-bottom: 20px;
-`;
 
 export default PostedAt;

--- a/src/components/post/RegisterLabel.tsx
+++ b/src/components/post/RegisterLabel.tsx
@@ -3,7 +3,7 @@ import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { cx } from 'styled-system/css';
 import { styled } from 'styled-system/jsx';
 import { Flex } from '@/styles/layout';
-import { Medium } from '@/styles/styles';
+import { HomeRegistContainer, MarginT16 } from '@/styles/styles';
 
 const RegisterLabel = ({
   label,
@@ -13,21 +13,16 @@ const RegisterLabel = ({
   essential?: boolean;
 }) => {
   return (
-    <RegisterLabelContiner className={cx(Medium, Flex)}>
+    <div className={cx(HomeRegistContainer, MarginT16, Flex)}>
       {label}
       {essential && (
         <IconContainer>
           <Icon {...iconPropsGenerator('essential', '7')} />
         </IconContainer>
       )}
-    </RegisterLabelContiner>
+    </div>
   );
 };
-
-const RegisterLabelContiner = styled.div`
-  margin-top: 16px;
-  font-size: var(--font-sizes-base);
-`;
 
 const IconContainer = styled.div`
   margin: 4px 3px;

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -2,7 +2,6 @@ import PostSocial from '@/components/post/PostSocial';
 import MiniProfile from '@/components/common/MiniProfile';
 import Icon from '@/components/common/Icon';
 import CafeDetail from '@/components/post/CafeDetail';
-
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { SimplifyUser } from '@/types/types';
 import { styled } from 'styled-system/jsx';

--- a/src/components/profile/FollowCount.tsx
+++ b/src/components/profile/FollowCount.tsx
@@ -1,14 +1,7 @@
 import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { FollowCountProps } from '@/types/types';
-import { Align, Column, FlexCenter, MarginAuto } from '@/styles/layout';
-import {
-  Semibold,
-  Border16,
-  Cursor,
-  LineH18,
-  TextBlack,
-  TextGray
-} from '@/styles/styles';
+import { Center, Column, Flex, MarginAuto } from '@/styles/layout';
+import { Border16, Cursor, RecentSearch, SumType } from '@/styles/styles';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 
@@ -22,22 +15,19 @@ const FollowCount: React.FC<FollowCountProps> = ({ icons }) => {
   };
 
   return (
-    <Container className={cx(FlexCenter, Cursor, Border16)}>
+    <Container className={cx(Flex, Cursor, Border16)}>
       {icons.map((icon, index) => (
         <Stat
           key={index}
           className={cx(
-            Align,
+            Center,
             Column,
             MarginAuto,
-            LineH18,
             index === icons.length - 1 ? 'lastStat' : ''
           )}
           onTouchEnd={() => handleStatClick(icon.label)}>
-          <StatNumber className={cx(TextBlack, Semibold)}>
-            {icon.number}
-          </StatNumber>
-          <StatLabel className={cx(TextGray, LineH18)}>{icon.label}</StatLabel>
+          <StatNumber className={RecentSearch}>{icon.number}</StatNumber>
+          <StatLabel className={SumType}>{icon.label}</StatLabel>
         </Stat>
       ))}
     </Container>
@@ -51,20 +41,16 @@ const Container = styled.div`
   background-color: var(--colors-tertiary);
 `;
 const Stat = styled.div`
-  padding: 0px 25px;
+  padding: 0px 39px;
   border-right: 1px solid #dbdbdb;
   &.lastStat {
     border-right: none;
   }
 `;
 const StatNumber = styled.li`
-  font-size: var(--font-sizes-base);
-  margin: 0px 18px;
   list-style-type: none;
 `;
 const StatLabel = styled.li`
-  font-size: var(--font-sizes-xs);
-  margin: 0px 10px;
   list-style-type: none;
 `;
 export default FollowCount;

--- a/src/components/profile/ProfileDetail.tsx
+++ b/src/components/profile/ProfileDetail.tsx
@@ -8,34 +8,27 @@ import {
   brand
 } from '@/constants/Profile';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
-import { Between, Column, Flex, FlexCenter } from '@/styles/layout';
-import {
-  TextBlack,
-  TextGray,
-  Border16,
-  Bold,
-  Regular,
-  TextArea
-} from '@/styles/styles';
+import { Between, Column, FlexCenter, Center, Align } from '@/styles/layout';
+import { Border16, PrfileTitle, SmStyle, TextArea } from '@/styles/styles';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 
 const ProfileDetail = () => {
   return (
-    <Container className={cx(Column, FlexCenter)}>
-      <UserTitle className={cx(FlexCenter, TextBlack, Bold)}>
+    <Container className={cx(Column, Center)}>
+      <UserTitle className={cx(FlexCenter, PrfileTitle)}>
         {userNickName.loginName}
       </UserTitle>
-      <UserText className={cx(FlexCenter, Regular)}>
-        <span className={TextBlack}>{userName.user1}</span>
-        <span className={TextGray}>{userEmail.eMail}</span>
+      <UserText className={cx(FlexCenter, SmStyle)}>
+        <span>{userName.user1}</span>
+        <UserNameText>{userEmail.eMail}</UserNameText>
       </UserText>
-      <Info className={cx(FlexCenter, Between)}>
-        <UserBrand className={cx(Flex, Border16)}>
+      <Info className={cx(Align, Between)}>
+        <UserBrand className={cx(FlexCenter, Border16)}>
           <Icon {...iconPropsGenerator('brand')} />
           <div className={TextArea}>{brand.brand1}</div>
         </UserBrand>
-        <UserSubTitle className={cx(Flex, Border16)}>
+        <UserSubTitle className={cx(FlexCenter, Border16)}>
           <Icon {...iconPropsGenerator('coffeebean')} />
           <div
             className={
@@ -52,13 +45,15 @@ const Container = styled.div`
 `;
 const UserTitle = styled.span`
   width: 200px;
-  font-size: var(--font-sizes-xxl);
   margin: 22px 0px 2px 0px;
 `;
 const UserText = styled.div`
-  font-size: var(--font-sizes-sm);
   margin-bottom: 16px;
   gap: 4px;
+`;
+const UserNameText = styled.span`
+  color: #767676 !important;
+  font-weight: 400;
 `;
 const Info = styled.div`
   gap: 8px;

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -5,7 +5,7 @@ import Icon from '@/components/common/Icon';
 import { SEARCH_TEXTS } from '@/constants/search';
 import { SearchBarProps } from '@/types/types';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
-import { Between, Flex, FlexCenter } from '@/styles/layout';
+import { Align, Between, Flex, FlexCenter } from '@/styles/layout';
 import { SearchInput } from '@/styles/styles';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
@@ -31,8 +31,8 @@ const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
 
   return (
     <>
-      <div className={cx(Flex, Between)}>
-        <Container className={Flex}>
+      <div className={cx(Align, Between)}>
+        <Container className={cx(Align, Between)}>
           <Area className={Flex}>
             <IconContainer className={FlexCenter}>
               <Icon {...iconPropsGenerator('mini-search', '12')} />
@@ -47,11 +47,11 @@ const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
             />
           </Area>
           {inputValue && (
-            <div
+            <IconDelete
               className={FlexCenter}
               onTouchEnd={handleInputDelete}>
               <Icon {...iconPropsGenerator('input-delete', '24')} />
-            </div>
+            </IconDelete>
           )}
         </Container>
         <Button
@@ -74,13 +74,14 @@ const Container = styled.div`
   background-color: var(--colors-tertiary);
   border-radius: 6px;
 `;
-
 const Area = styled.div`
   height: 32px;
 `;
-
 const IconContainer = styled.div`
   padding: 10px;
+`;
+const IconDelete = styled.div`
+  padding: 4px;
 `;
 const Divider = styled.div`
   position: relative;

--- a/src/components/search/SearchListItem.tsx
+++ b/src/components/search/SearchListItem.tsx
@@ -34,7 +34,7 @@ const SearchListItem: React.FC<{ users: SimplifyUser[] }> = () => {
   return (
     <>
       {filteredResults.length > 0 && !inputValue && (
-        <Wrapper className={cx(Flex, Align, Between)}>
+        <Wrapper className={cx(Align, Between)}>
           <span className={RecentSearch}>{SEARCH_TEXTS.recentSearch}</span>
           <span
             className={DeleteAllBtn}
@@ -46,7 +46,7 @@ const SearchListItem: React.FC<{ users: SimplifyUser[] }> = () => {
       {filteredResults.map(({ userId, NickName, caffeine }: SimplifyUser) => (
         <Container
           key={userId}
-          className={cx(Flex, Align, Between)}>
+          className={cx(Align, Between)}>
           <div onTouchEnd={handleInUsers}>
             <MiniProfile
               userId={userId}

--- a/src/components/start/BrandItem.tsx
+++ b/src/components/start/BrandItem.tsx
@@ -4,11 +4,11 @@ import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import useSetUserInitialInfo from '@/hooks/useSetUserInitialInfo';
 import { BrnadItemProps } from '@/types/types';
 import { authState } from '@/atoms/atoms';
-
 import { styled } from 'styled-system/jsx';
 import { css, cx } from 'styled-system/css';
 import { Center, Column } from '@/styles/layout';
 import convertBrandName from '@/utils/convertBrandName';
+import { SmStyle } from '@/styles/styles';
 
 const BrandItem = (brandInfo: BrnadItemProps) => {
   const { user } = useRecoilValue(authState);
@@ -35,7 +35,8 @@ const BrandItem = (brandInfo: BrnadItemProps) => {
           ? SelectedBrandContainer
           : DefaltBrandContainer,
         Column,
-        Center
+        Center,
+        SmStyle
       )}>
       {selectedIcon}
       <IconContainer>
@@ -63,10 +64,6 @@ const ItemContainer = styled.div`
   position: relative;
   border-radius: 16px;
   padding: 14px 0;
-  text-align: center;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 20px;
 `;
 
 const SelectedBrandContainer = css`

--- a/src/components/start/CheckNickname.tsx
+++ b/src/components/start/CheckNickname.tsx
@@ -1,16 +1,16 @@
+import { useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { Input } from '@/components/common/Input';
-import { Label } from '@/components/common/Label';
-import { INPUT_TEXTS } from '@/constants/common';
-import { LABEL_TEXTS } from '@/constants/common';
+import { getNicknameList } from '@/api/user';
 import {
   inputNicknameAlertState,
   authState,
   useInputState
 } from '@/atoms/atoms';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { INPUT_TEXTS } from '@/constants/common';
+import { LABEL_TEXTS } from '@/constants/common';
 import useSetUserInitialInfo from '@/hooks/useSetUserInitialInfo';
-import { getNicknameList } from '@/api/user';
-import { useState } from 'react';
 
 const { nickname } = INPUT_TEXTS.type;
 

--- a/src/components/start/InitialForm.tsx
+++ b/src/components/start/InitialForm.tsx
@@ -16,7 +16,9 @@ import {
   DisabledBtn,
   Regular,
   Semibold,
-  StartPageContainer
+  StartPageContainer,
+  PrfileTitle,
+  MarginT28
 } from '@/styles/styles';
 import { cx } from 'styled-system/css';
 
@@ -32,12 +34,12 @@ const InitialForm = () => {
   return (
     <div className={Column}>
       <div className={StartPageContainer}>
-        <InitialFormText className={Regular}>
+        <div className={cx(Regular, PrfileTitle, MarginT28)}>
           {message.first}
           <br />
           <span className={Semibold}>{message.profile}</span>
           {message.second}
-        </InitialFormText>
+        </div>
         <ProfileContainer>
           <EditProfileImg onImageSelect={handleImageSelect} />
         </ProfileContainer>
@@ -61,13 +63,6 @@ const InitialForm = () => {
     </div>
   );
 };
-
-const InitialFormText = styled.div`
-  margin-top: 28px;
-  color: #313131;
-  font-size: var(--font-sizes-xxl);
-  line-height: 32px;
-`;
 
 const ProfileContainer = styled.div`
   margin: 50px 36px;

--- a/src/components/start/InitialForm.tsx
+++ b/src/components/start/InitialForm.tsx
@@ -27,7 +27,7 @@ const { message } = INITIAL_FORM_TEXTS;
 const InitialForm = () => {
   useComposeHeader(false, '기본정보', 'close');
   const { user } = useRecoilValue(authState);
-  const { handleFormSubmit, setImageUrl } = useImgSubmit();
+  const { setImageUrl } = useImgSubmit();
   const handleImageSelect = (selectedImage: File) => {
     setImageUrl(URL.createObjectURL(selectedImage));
   };

--- a/src/components/start/SelectFavBrand.tsx
+++ b/src/components/start/SelectFavBrand.tsx
@@ -3,7 +3,6 @@ import { setInitialInfo } from '@/api/user';
 import { authState } from '@/atoms/atoms';
 import BrandItem from '@/components/start/BrandItem';
 import Button from '@/components/common/Button';
-
 import { SELECTFAVBRAND_TEXTS } from '@/constants/start';
 import { BUTTON_TEXTS } from '@/constants/common';
 import { useComposeHeader } from '@/hooks/useComposeHeader';
@@ -28,7 +27,7 @@ const { message } = SELECTFAVBRAND_TEXTS;
 export const SelectFavBrand = () => {
   useComposeHeader(false, '기본정보', 'close');
   const { user } = useRecoilValue(authState);
-  const { handleFormSubmit, setImageUrl } = useImgSubmit();
+  const { handleFormSubmit } = useImgSubmit();
 
   const navigateToHome = useNavigateTo('/');
   const navigateToMe = useNavigateTo('/start/3');
@@ -80,23 +79,6 @@ export const SelectFavBrand = () => {
     </>
   );
 };
-
-const InitialFormText = styled.div`
-  margin-top: 1.75rem;
-  color: #313131;
-  font-size: var(--font-sizes-xxl);
-  font-weight: 600;
-  line-height: 2rem;
-`;
-
-const SecondLine = styled.span`
-  color: #767676;
-  font-family: Pretendard;
-  font-size: 1rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 1.5rem;
-`;
 
 const BrandItemContainer = styled.div`
   margin: 2.375rem auto 3.75rem;

--- a/src/components/start/SelectFavBrand.tsx
+++ b/src/components/start/SelectFavBrand.tsx
@@ -13,7 +13,14 @@ import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { AuthTypes } from '@/types/types';
 import { styled } from 'styled-system/jsx';
 import { Grid } from '@/styles/layout';
-import { DefaultBtn, DisabledBtn, StartPageContainer } from '@/styles/styles';
+import {
+  DefaultBtn,
+  DisabledBtn,
+  StartPageContainer,
+  StartBrand,
+  StartBrandSub,
+  MarginT28
+} from '@/styles/styles';
 import { cx } from 'styled-system/css';
 
 const { message } = SELECTFAVBRAND_TEXTS;
@@ -49,11 +56,11 @@ export const SelectFavBrand = () => {
   return (
     <>
       <div className={StartPageContainer}>
-        <InitialFormText>
+        <div className={cx(StartBrand, MarginT28)}>
           <span>{message.first}</span>
           <br />
-          <SecondLine>{message.second}</SecondLine>
-        </InitialFormText>
+          <span className={StartBrandSub}>{message.second}</span>
+        </div>
         <BrandItemContainer className={Grid}>
           {brandList.map(item => (
             <BrandItem

--- a/src/components/start/SelectGender.tsx
+++ b/src/components/start/SelectGender.tsx
@@ -49,8 +49,6 @@ const SelectGender = () => {
   );
 };
 
-export default SelectGender;
-
 const NoneSelectedGender = css`
   border: 1px solid #ccc;
   color: #a6a6a6;
@@ -77,3 +75,5 @@ const SelectGenderContiner = styled.div`
   margin-top: 24px;
   height: auto;
 `;
+
+export default SelectGender;

--- a/src/components/start/SignIn.tsx
+++ b/src/components/start/SignIn.tsx
@@ -1,7 +1,7 @@
 import { useRecoilState } from 'recoil';
 import { GoogleAuthProvider } from 'firebase/auth';
 import { getUserInfo, signInWithGoogle } from '@/api/user';
-
+import { DocumentData } from 'firebase/firestore';
 import Icon from '@/components/common/Icon';
 import { SIGININ_TEXTS } from '@/constants/start';
 import { AuthTypes } from '@/types/types';
@@ -21,7 +21,7 @@ import {
   Flex,
   MarginAuto
 } from '@/styles/layout';
-import { Btn, SignInBtn } from '@/styles/styles';
+import { StartBtn, NoneBtn, SignInBtn } from '@/styles/styles';
 
 const { signInBtn, startText } = SIGININ_TEXTS;
 
@@ -80,11 +80,11 @@ const SignIn = () => {
             <use href={`/sprite.svg#icon-ddocker-logo`} />
           </svg>
         </AppLogo>
-        <StartText className={Btn}>
+        <div className={StartBtn}>
           {startText.first}
           <br />
           {startText.second}
-        </StartText>
+        </div>
       </AppLogoContainer>
       <SignInBtnContainer className={cx(Justify, Column)}>
         <KakaoBtn className={SignInBtn}>
@@ -102,13 +102,12 @@ const SignIn = () => {
           </IconContiner>
           <div>{signInBtn.google}</div>
         </GoogleBtn>
-        <NoneBtn
-          type="button"
-          className={Btn}
+        <button
+          className={NoneBtn}
           onClick={useNavigateTo('/')}
           onTouchEnd={useNavigateTo('/')}>
           {signInBtn.none}
-        </NoneBtn>
+        </button>
       </SignInBtnContainer>
     </Container>
   );
@@ -143,21 +142,9 @@ const GoogleBtn = styled.button`
   margin-top: 13px;
 `;
 
-const NoneBtn = styled.button`
-  font-size: var(--font-sizes-sm);
-  color: #767676;
-  line-height: 18px;
-  margin-top: 13px;
-`;
-
 const IconContiner = styled.div`
   position: absolute;
   left: 15px;
-`;
-
-const StartText = styled.div`
-  text-align: center;
-  font-size: var(--font-sizes-sm);
 `;
 
 export default SignIn;

--- a/src/components/start/SignIn.tsx
+++ b/src/components/start/SignIn.tsx
@@ -1,7 +1,6 @@
 import { useRecoilState } from 'recoil';
 import { GoogleAuthProvider } from 'firebase/auth';
 import { getUserInfo, signInWithGoogle } from '@/api/user';
-import { DocumentData } from 'firebase/firestore';
 import Icon from '@/components/common/Icon';
 import { SIGININ_TEXTS } from '@/constants/start';
 import { AuthTypes } from '@/types/types';
@@ -9,8 +8,6 @@ import { authState } from '@/atoms/atoms';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { useNavigateTo } from '@/hooks/useNavigateTo';
 import useSetCacheData from '@/hooks/useSetCacheData';
-import useGetCacheData from '@/hooks/useGetCacheData';
-
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 import {

--- a/src/pages/Page-Follow.tsx
+++ b/src/pages/Page-Follow.tsx
@@ -10,7 +10,8 @@ import {
   TextGray,
   ToggleButton,
   ToggleLeft,
-  ToggleRight
+  ToggleRight,
+  MarginT17
 } from '@/styles/styles';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
@@ -57,7 +58,7 @@ const Follow: React.FC<FollowCountProps> = () => {
   const handleMoveBtn = useNavigateTo('/search');
   return (
     <>
-      <Container className={cx(FlexCenter, Column)}>
+      <div className={cx(FlexCenter, Column, MarginT17)}>
         <ToggleArea className={cx(Flex)}>
           <button
             className={cx(
@@ -84,7 +85,7 @@ const Follow: React.FC<FollowCountProps> = () => {
             {TEXT.toggleFollowingBtn}
           </button>
         </ToggleArea>
-      </Container>
+      </div>
 
       {usersToShow.length > 0 && <UserListItem users={usersToShow} />}
       {isActiveBtn === '팔로워' && !usersToShow.length && (
@@ -100,9 +101,6 @@ const Follow: React.FC<FollowCountProps> = () => {
   );
 };
 
-const Container = styled.div`
-  margin-top: 17px;
-`;
 const ToggleArea = styled.div`
   width: 100%;
   padding-bottom: 4px;

--- a/src/pages/Page-Home.tsx
+++ b/src/pages/Page-Home.tsx
@@ -16,8 +16,6 @@ const Home = () => {
   );
 };
 
-export default Home;
-
 const Container = styled.div`
   position: relative;
   height: calc(100vh+ 126px);
@@ -33,3 +31,5 @@ const Container = styled.div`
     z-index: -1;
   }
 `;
+
+export default Home;

--- a/src/pages/Page-Post.tsx
+++ b/src/pages/Page-Post.tsx
@@ -1,6 +1,6 @@
+import { lazy } from 'react';
 import { useParams } from 'react-router-dom';
 import { useComposeHeader } from '@/hooks/useComposeHeader';
-import { lazy } from 'react';
 
 const PostRegister = lazy(() => import('../components/post/PostRegister'));
 const PostDetail = lazy(() => import('../components/post/PostDetail'));

--- a/src/pages/Page-Posts.tsx
+++ b/src/pages/Page-Posts.tsx
@@ -1,5 +1,5 @@
-import { useComposeHeader } from '@/hooks/useComposeHeader';
 import PostCard from '@/components/posts/PostCard';
+import { useComposeHeader } from '@/hooks/useComposeHeader';
 import { styled } from 'styled-system/jsx';
 
 export const Posts = () => {

--- a/src/pages/Page-Profile.tsx
+++ b/src/pages/Page-Profile.tsx
@@ -1,5 +1,5 @@
-import { imageState } from '@/atoms/atoms';
 import { useRecoilState } from 'recoil';
+import { imageState } from '@/atoms/atoms';
 import FollowCount from '@/components/profile/FollowCount';
 import PostsGrid from '@/components/profile/PostsGrid';
 import ProfileDetail from '@/components/profile/ProfileDetail';

--- a/src/pages/Page-Search.tsx
+++ b/src/pages/Page-Search.tsx
@@ -1,8 +1,8 @@
+import { useRecoilState } from 'recoil';
+import { searchResultsState } from '@/atoms/atoms';
 import SearchBar from '@/components/search/SearchBar';
 import SearchListItem from '@/components/search/SearchListItem';
 import { SimplifyUser } from '@/types/types';
-import { useRecoilState } from 'recoil';
-import { searchResultsState } from '@/atoms/atoms';
 
 const Search = () => {
   const [searchResults, setSearchResults] = useRecoilState(searchResultsState);

--- a/src/pages/Page-Start.tsx
+++ b/src/pages/Page-Start.tsx
@@ -1,15 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-
 import { authState } from '@/atoms/atoms';
 import SignIn from '@/components/start/SignIn';
 import InitialForm from '@/components/start/InitialForm';
 import { SelectFavBrand } from '@/components/start/SelectFavBrand';
-
-import { authState } from '@/atoms/atoms';
 import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { useShowFooter } from '@/hooks/useShowFooter';
 import useGetCacheData from '@/hooks/useGetCacheData';

--- a/src/pages/Page-Start.tsx
+++ b/src/pages/Page-Start.tsx
@@ -1,7 +1,10 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
+import { authState } from '@/atoms/atoms';
 import SignIn from '@/components/start/SignIn';
 import InitialForm from '@/components/start/InitialForm';
 import { SelectFavBrand } from '@/components/start/SelectFavBrand';

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -606,3 +606,35 @@ export const StartBrandSub = cx(
     font-size: var(--font-sizes-base);
     line-height: 24px;
   `)
+  
+export const RegistCoffeeBtn = cx(
+  Medium,
+  css`
+    color: #767676;
+    font-size: var(--font-sizes-xxl);
+    line-height: 32px;
+  `)
+  
+export const AlertMessage = cx(
+  Regular,
+  css`
+    color: #a6a6a6;
+    font-size: var(--font-sizes-sm);
+    line-height: 22px;
+  `)
+
+export const CommnetUser = cx(
+  Semibold,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-sm);
+    line-height: 22px;
+  `)
+  
+export const CommentLength = cx(
+  Regular,
+  css`
+    color: #767676;
+    font-size: var(--font-sizes-sm);
+    line-height: 22px;
+  `)

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -24,8 +24,25 @@ export const Btn = cx(
   Medium,
   css`
     width: 100%;
-  `
-);
+  `);
+
+export const StartBtn = cx(
+  Btn,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-sm);
+    line-height: 22px;
+    text-align: center;
+  `)
+  
+export const NoneBtn = cx(
+  Btn,
+  css`
+    font-size: var(--font-sizes-sm);
+    color: #767676;
+    line-height: 18px;
+    margin-top: 13px;
+  `)
 
 export const ThinBtn = css`
   border-radius: 10px;
@@ -153,11 +170,28 @@ export const InputFontBase = cx(
   `
 );
 
+export const InputByteCheck = cx(
+  Regular,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-xs);
+    line-height: 20px;
+  `)
+    
 export const Cafe = css`
+  color: #767676;
   font-size: var(--font-sizes-xs);
   line-height: 20px;
-  color: #767676;
 `;
+
+export const CafeMedium = cx(
+  Medium,
+  Cafe,
+)
+
+export const BgF5 = css`
+  background-color: #f5f5f5;
+`
 
 export const PaddingL12 = css`
   padding-left: 12px;
@@ -167,8 +201,57 @@ export const PaddingL6 = css`
   padding-left: 6px;
 `;
 
+export const PaddingL63 = css`
+  padding-left: 63px;
+`
+
+export const PaddingL24 = css`
+  padding-left: 24px;
+`
+
 export const PaddingT12 = css`
   padding-top: 12px;
+`;
+
+export const PaddingT20 = css`
+ padding-top: 20px;
+`
+
+export const PaddingT22 = css`
+  padding-top: 22px;
+`
+
+export const PaddingB20 = css`
+  padding-bottom: 20px;
+`
+
+export const PaddingTBMix = cx(
+  PaddingT12,
+  PaddingB20,
+);
+
+export const MarginT12 = css`
+  margin-top: 12px;
+`
+
+export const MarginT16 = css`
+  margin-top: 16px;
+`
+
+export const MarginT17 = css`
+  margin-top: 17px;
+`
+
+export const MarginT28 = css`
+  margin-top: 28px;
+`
+
+export const MarginB6 = css`
+  margin-bottom: 6px;
+`
+
+export const MarginB8 = css`
+  margin-bottom: 8px;
 `;
 
 export const PostsCafe = css`
@@ -192,10 +275,13 @@ export const PostContent = styled.div`
   padding-bottom: 16px;
 `;
 
-export const CaffeineDetail = styled.div`
-  line-height: 22px;
-  font-size: var(--font-sizes-sm);
-`;
+export const CaffeineDetail = cx(
+  Regular,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-sm);
+    line-height: 22px;
+  `);
 
 export const SearchInput = cx(
   Regular,
@@ -235,11 +321,10 @@ export const Border16 = css`
 export const TextArea = cx(
   Regular,
   css`
-    margin: 3px 0px 3px 0px;
     color: #fff;
     font-size: var(--font-sizes-xs);
-  `
-);
+    line-height: 20px;
+  `)
 
 export const ButtonArea = cx(
   Medium,
@@ -336,6 +421,14 @@ export const DeleteAllBtn = cx(
   `
 );
 
+export const DelBtn = cx(
+  Medium,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-xs);
+    line-height: 20px;
+  `)
+
 export const SearchPageHeight = css`
   height: calc(
     100dvh - 52px - env(safe-area-inset-bottom) - env(safe-area-inset-top)
@@ -353,3 +446,163 @@ export const GeneralHeight = css`
 export const StartPageHeight = css`
   height: calc(100dvh - env(safe-area-inset-bottom) - env(safe-area-inset-top));
 `;
+
+export const SumTitle = cx(
+  Semibold,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-lg);
+    line-height: 26px;
+  `)
+
+export const SumBoardTitle = cx(
+  Medium,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-sm);
+    line-height: 22px;
+  `)
+  
+export const SumType = cx(
+  Regular,
+  css`
+    color: #767676;
+    font-size: var(--font-sizes-xs);
+    line-height: 20px;
+  `)
+
+export const SumTypeAmount = cx(
+  Bold,
+  css`
+    color: var(--colors-main);
+    font-size: var(--font-sizes-xl);
+    line-height: 28px;
+  `)
+
+export const SumTypeUnit = cx(
+  Medium,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-sm);
+    line-height: 28px;
+    transform: translateY(7%);
+  `)
+  
+export const HomeRegistContainer = cx(
+  Medium,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-base);
+    line-height: 24px;
+  `)
+
+export const HomeInfoCaffeine = cx(
+  Semibold,
+  css`
+    color: var(--colors-main);
+    font-size: var(--font-sizes-xl);
+    line-height: 28px;
+  `)
+
+export const SmStyle = cx(
+  Medium,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-sm);
+    line-height: 22px;
+  `)
+  
+export const FooterTextMedium = cx(
+  Medium,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-xxs);
+    line-height: 18px;
+  `)
+
+export const FooterTextSelected = cx(
+  Semibold,
+  css`
+    color: var(--colors-main);
+    font-size: var(--font-sizes-xxs);
+    line-height: 18px;
+  `)
+  
+export const HeaderText = cx(
+  Medium,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-lg);
+    line-height: 26px;
+  `)
+  
+export const ProfileTitle = cx(
+  Semibold,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-sm);
+    line-height: 18px;
+  `)
+
+export const ProfileInfo = cx(
+  Regular,
+  css`
+    color: #767676;
+    font-size: var(--font-sizes-xs);
+    line-height: 18px;
+  `)
+  
+export const HomeContent = cx(
+  Semibold,
+  css`
+    color: var(--colors-main);
+    font-size: var(--font-sizes-base);
+    line-height: 36px;
+  `)
+  
+export const HomeContentBigNum = cx(
+  Bold,
+  css`
+    font-size: var(--font-sizes-xxl);
+    line-height: 40px;
+  `)
+  
+export const HomeContentNum = cx(
+  Semibold,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-base);
+    line-height: 36px;
+  `)
+  
+export const HomeHeaderContent = cx(
+  Medium,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-xl);
+    line-height: 28px;
+  `)
+  
+export const PrfileTitle = cx(
+  Bold,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-xxl);
+    line-height: 32px;
+  `)
+  
+export const StartBrand = cx(
+  Semibold,
+  css`
+    color: #313131;
+    font-size: var(--font-sizes-xxl);
+    line-height: 32px;
+  `)
+
+export const StartBrandSub = cx(
+  Regular,
+  css`
+    color: #767676;
+    font-size: var(--font-sizes-base);
+    line-height: 24px;
+  `)


### PR DESCRIPTION
## ☕ PR 타입

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [x] 사소한 수정

## ☕ 작업 내용

- 변경 전
<img width="500" alt="image" src="https://github.com/7-7-2/DDocker_FE/assets/96659041/6f5698c4-bd7d-45f9-b707-4a43cd62fcb5">

- 변경 후
<img width="500" alt="image" src="https://github.com/7-7-2/DDocker_FE/assets/96659041/d80ff958-b971-4487-ade2-ee4a8639687c">
<img width="350" alt="image" src="https://github.com/7-7-2/DDocker_FE/assets/96659041/6f3f8570-df2e-4678-b945-f725cb23e725">
<img width="300" alt="image" src="https://github.com/7-7-2/DDocker_FE/assets/96659041/c86e72f9-280b-43ee-bb03-66589cbe29b6">


## ☕ 관련 issue

- 사전에 정의한 컨벤션을 반영했습니다.
- 스타일 부분에서 누락 된 부분이 남아있을 수 있습니다.
- 재 사용을 위해 `@/styles/styles` 모듈에서 정의되어있는 변수를 불러와 사용했지만,
  추후 직관적인 변수 명을 정의해야 할 필요가 있을 것 같습니다.

closed #84 